### PR TITLE
Fix master

### DIFF
--- a/devpi-web-package/default.nix
+++ b/devpi-web-package/default.nix
@@ -20,11 +20,11 @@
 
 buildPythonPackage rec {
   pname = "devpi_web";
-  version = "5.1.0";
+  version = "5.0.1";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-zeET0D/yGVjFTlH+sxVajfJeilZ4UDkOk5vUqya+btw=";
+    hash = "sha256-Rh+U3AKYXMYIp4pZYG3LITXIap5xaxicnDdqGfl+SB8=";
   };
 
   buildInputs = [

--- a/flake.lock
+++ b/flake.lock
@@ -20,16 +20,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1780203844,
-        "narHash": "sha256-K5sT4jTpGs15ADhviMKNBH38REpPf5Q6mM1+N6cArVE=",
+        "lastModified": 1764522689,
+        "narHash": "sha256-SqUuBFjhl/kpDiVaKLQBoD8TLD+/cTUzzgVFoaHrkqY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b51242d7d43689db2f3be91bd05d5b24fbb469c4",
+        "rev": "8bb5646e0bed5dbd3ab08c7a7cc15b75ab4e1d0f",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-26.05",
+        "ref": "nixos-25.11",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "devpi-server with the devpi-web plugin.";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-26.05";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.11";
     flake-utils.url = "github:numtide/flake-utils";
   };
 
@@ -32,12 +32,12 @@
         devpi-web = (
           final.python3Packages.callPackage ./devpi-web-package {
             # break loop by using unaltered (super) devpi-server
-            devpi-server = prev.python3Packages.devpi-server;
+            devpi-server = prev.devpi-server;
           }
         );
 
         devpi-server = prev.devpi-server.overrideAttrs (oa: {
-          propagatedBuildInputs = (oa.propagatedBuildInputs or []) ++ [ final.devpi-web ];
+          propagatedBuildInputs = oa.propagatedBuildInputs ++ [ final.devpi-web ];
         });
 
         meta = with final.lib; {


### PR DESCRIPTION
This reverts commit dbb6ff7ff9712ed41708a26785b052c3404edda9.

Revert "flake: devpi lives in python3Packages"

This reverts commit 143464f0e206fb753a6a8a60c2e05c50676af128.

Revert "flake(fix): propagatedBuildInputs is empty"

This reverts commit 70e0f26656f760d49ee7cd0c6fa4ddcf042ac626.

Revert "flake: bump nixpkgs"

This reverts commit 70ea38f639a8f4e3f44555746044c4f14c2a7308.